### PR TITLE
home: add lowbatt module and enable the service

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -4,6 +4,8 @@ let
   system-path = builtins.toPath /code/personal/base/src/github.com/kalbasit/system;
 in {
   imports = [
+    ./modules/home-manager/lowbatt
+
     ./cfg/home-manager/alacritty
     ./cfg/home-manager/chromium
     ./cfg/home-manager/dunst
@@ -30,6 +32,9 @@ in {
     defaultCacheTtl = 68400;
     maxCacheTtl = 68400;
   };
+
+  # enable batteryNotifier
+  services.batteryNotifier.enable = true;
 
   # Install and enable Keybase
   services.keybase.enable = true;

--- a/modules/home-manager/lowbatt/default.nix
+++ b/modules/home-manager/lowbatt/default.nix
@@ -6,6 +6,30 @@ with lib;
 
 let
   cfg = config.services.batteryNotifier;
+  script = pkgs.writeTextFile {
+    name = "unit-script";
+    executable = true;
+    destination = "/bin/lowbatt-start";
+    text = ''
+        export battery_capacity=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/capacity)
+        export battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
+
+        if [[ $battery_capacity -le ${builtins.toString cfg.notifyCapacity} && $battery_status = "Discharging" ]]; then
+            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Low" "You should probably plug-in."
+        fi
+
+        if [[ $battery_capacity -le ${builtins.toString cfg.hibernateCapacity} && $battery_status = "Discharging" ]]; then
+            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Critically Low" "Computer will hibernate in 60 seconds."
+            sleep 60s
+
+            battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
+            if [[ $battery_status = "Discharging" ]]; then
+                systemctl hibernate
+            fi
+        fi
+    '';
+  };
+
 in {
   options = {
     services.batteryNotifier = {
@@ -38,33 +62,30 @@ in {
 
   config = mkIf cfg.enable {
     systemd.user.timers."lowbatt" = {
-      description = "check battery level";
-      timerConfig.OnBootSec = "1m";
-      timerConfig.OnUnitInactiveSec = "1m";
-      timerConfig.Unit = "lowbatt.service";
-      wantedBy = ["timers.target"];
+      Unit = {
+        Description = "check battery level";
+      };
+
+      Timer = {
+        OnBootSec = "1m";
+        OnUnitInactiveSec = "1m";
+        Unit = "lowbatt.service";
+      };
+
+      Install = {
+        WantedBy = [ "timers.target" ];
+      };
     };
+
     systemd.user.services."lowbatt" = {
-      description = "battery level notifier";
-      serviceConfig.PassEnvironment = "DISPLAY";
-      script = ''
-        export battery_capacity=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/capacity)
-        export battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
+      Unit = {
+        Description = "battery level notifier";
+      };
 
-        if [[ $battery_capacity -le ${builtins.toString cfg.notifyCapacity} && $battery_status = "Discharging" ]]; then
-            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Low" "You should probably plug-in."
-        fi
-
-        if [[ $battery_capacity -le ${builtins.toString cfg.hibernateCapacity} && $battery_status = "Discharging" ]]; then
-            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Critically Low" "Computer will hibernate in 60 seconds."
-            sleep 60s
-
-            battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
-            if [[ $battery_status = "Discharging" ]]; then
-                systemctl hibernate
-            fi
-        fi
-      '';
+      Service = {
+        PassEnvironment = "DISPLAY";
+        ExecStart = "${script}/bin/lowbatt-start";
+      };
     };
   };
 }

--- a/modules/home-manager/lowbatt/default.nix
+++ b/modules/home-manager/lowbatt/default.nix
@@ -1,0 +1,70 @@
+# TODO: see https://github.com/rycee/home-manager/issues/250 for instructions
+
+{ config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  cfg = config.services.batteryNotifier;
+in {
+  options = {
+    services.batteryNotifier = {
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to enable battery notifier.
+        '';
+      };
+      device = mkOption {
+        default = "BAT0";
+        description = ''
+          Device to monitor.
+        '';
+      };
+      notifyCapacity = mkOption {
+        default = 10;
+        description = ''
+          Battery level at which a notification shall be sent.
+        '';
+      };
+      hibernateCapacity = mkOption {
+        default = 5;
+        description = ''
+          Battery level at which a hibernate unless connected shall be sent.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.timers."lowbatt" = {
+      description = "check battery level";
+      timerConfig.OnBootSec = "1m";
+      timerConfig.OnUnitInactiveSec = "1m";
+      timerConfig.Unit = "lowbatt.service";
+      wantedBy = ["timers.target"];
+    };
+    systemd.user.services."lowbatt" = {
+      description = "battery level notifier";
+      serviceConfig.PassEnvironment = "DISPLAY";
+      script = ''
+        export battery_capacity=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/capacity)
+        export battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
+
+        if [[ $battery_capacity -le ${builtins.toString cfg.notifyCapacity} && $battery_status = "Discharging" ]]; then
+            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Low" "You should probably plug-in."
+        fi
+
+        if [[ $battery_capacity -le ${builtins.toString cfg.hibernateCapacity} && $battery_status = "Discharging" ]]; then
+            ${pkgs.libnotify}/bin/notify-send --urgency=critical --hint=int:transient:1 --icon=battery_empty "Battery Critically Low" "Computer will hibernate in 60 seconds."
+            sleep 60s
+
+            battery_status=$(${pkgs.coreutils}/bin/cat /sys/class/power_supply/${cfg.device}/status)
+            if [[ $battery_status = "Discharging" ]]; then
+                systemctl hibernate
+            fi
+        fi
+      '';
+    };
+  };
+}


### PR DESCRIPTION
The lowbatt service monitors the battery and notifies the user if the battery is at or below 10% and will hibernate the laptop if the battery is at or below 5%.