### PR TITLE
nixos: dynamically create users; generate their HM config through a function call

### DIFF
--- a/hosts/cratos/home.nix
+++ b/hosts/cratos/home.nix
@@ -1,5 +1,5 @@
 {
-  home-manager.users.kalbasit = { ... }: {
+  mine.home-manager.config = { name, uid, isAdmin, nixosConfig }: { ... }: {
     imports = [
       ../../modules/home
     ];

--- a/hosts/cratos/home.nix
+++ b/hosts/cratos/home.nix
@@ -4,6 +4,8 @@
       ../../modules/home
     ];
 
+    mine.nixosConfig = nixosConfig;
+
     mine.batteryNotifier.enable = true;
     mine.git.enable = true;
     mine.less.enable = true;

--- a/hosts/hades/home.nix
+++ b/hosts/hades/home.nix
@@ -1,5 +1,5 @@
 {
-  mine.home-manager.users.kalbasit = { ... }: {
+  mine.home-manager.config = { attrs }: { ... }: {
     imports = [
       ../../modules/home
     ];

--- a/hosts/hades/home.nix
+++ b/hosts/hades/home.nix
@@ -4,6 +4,8 @@
       ../../modules/home
     ];
 
+    mine.nixosConfig = nixosConfig;
+
     mine.batteryNotifier.enable = true;
     mine.git.enable = true;
     mine.gnupg.enable = true;

--- a/hosts/hades/home.nix
+++ b/hosts/hades/home.nix
@@ -1,5 +1,5 @@
 {
-  mine.home-manager.config = { attrs }: { ... }: {
+  mine.home-manager.config = { name, uid, isAdmin, nixosConfig }: { ... }: {
     imports = [
       ../../modules/home
     ];

--- a/hosts/hades/home.nix
+++ b/hosts/hades/home.nix
@@ -1,5 +1,5 @@
 {
-  home-manager.users.kalbasit = { ... }: {
+  mine.home-manager.users.kalbasit = { ... }: {
     imports = [
       ../../modules/home
     ];

--- a/hosts/zeus/home.nix
+++ b/hosts/zeus/home.nix
@@ -4,6 +4,8 @@
       ../../modules/home
     ];
 
+    mine.nixosConfig = nixosConfig;
+
     mine.batteryNotifier.enable = true;
     mine.git.enable = true;
     mine.gnupg.enable = true;

--- a/hosts/zeus/home.nix
+++ b/hosts/zeus/home.nix
@@ -1,5 +1,5 @@
 {
-  home-manager.users.kalbasit = { ... }: {
+  mine.home-manager.config = { name, uid, isAdmin, nixosConfig }: { ... }: {
     imports = [
       ../../modules/home
     ];

--- a/modules/home/generic/nixos.nix
+++ b/modules/home/generic/nixos.nix
@@ -6,7 +6,8 @@ with lib;
   options.mine.nixosConfig = mkOption {
     default = {};
     defaultText = ''
-      NixOS configuration, set only on NixOS machines
+      NixOS configuration. On NixOS machines, it should be the config itself.
+      On non-NixOS machines, all the required keys must be set manually.
     '';
   };
 }

--- a/modules/home/generic/nixos.nix
+++ b/modules/home/generic/nixos.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+
+with lib;
+
+{
+  options.mine.nixosConfig = mkOption {
+    default = {};
+    defaultText = ''
+      NixOS configuration, set only on NixOS machines
+    '';
+  };
+}

--- a/modules/home/workstation/i3/default.nix
+++ b/modules/home/workstation/i3/default.nix
@@ -7,6 +7,6 @@ with lib;
 
   config = mkIf config.mine.workstation.i3.enable {
     home.file.".config/i3status/config".text = builtins.readFile ./i3status-config;
-    xsession.windowManager.i3 = import ./i3-config.lib.nix { inherit pkgs; };
+    xsession.windowManager.i3 = import ./i3-config.lib.nix { inherit config pkgs; };
   };
 }

--- a/modules/home/workstation/i3/i3-config.lib.nix
+++ b/modules/home/workstation/i3/i3-config.lib.nix
@@ -1,4 +1,4 @@
-{ pkgs, systemConfig ? (import <nixpkgs/nixos> {}).config, ... }:
+{ config, pkgs, ... }:
 
 let
   defaultModifier = "Mod4";
@@ -8,30 +8,30 @@ let
   locker = "${pkgs.xautolock}/bin/xautolock -locknow && sleep 1";
 
   intMonitor =
-    if systemConfig.networking.hostName == "hades"
+    if config.mine.nixosConfig.networking.hostName == "hades"
     then "eDP-1"
-    else if systemConfig.networking.hostName == "cratos"
+    else if config.mine.nixosConfig.networking.hostName == "cratos"
     then "eDP1"
     else "";
 
   intMode =
-    if systemConfig.networking.hostName == "hades"
+    if config.mine.nixosConfig.networking.hostName == "hades"
     then "1920x1080"
-    else if systemConfig.networking.hostName == "cratos"
+    else if config.mine.nixosConfig.networking.hostName == "cratos"
     then "3200x1800"
     else "";
 
   intScale =
-    if systemConfig.networking.hostName == "hades"
+    if config.mine.nixosConfig.networking.hostName == "hades"
     then "1x1"
-    else if systemConfig.networking.hostName == "cratos"
+    else if config.mine.nixosConfig.networking.hostName == "cratos"
     then "0.6x0.6"
     else "";
 
   extMonitor =
-    if systemConfig.networking.hostName == "hades"
+    if config.mine.nixosConfig.networking.hostName == "hades"
     then "DP-2"
-    else if systemConfig.networking.hostName == "cratos"
+    else if config.mine.nixosConfig.networking.hostName == "cratos"
     then "DP1-2"
     else "";
 

--- a/modules/nixos/general/home-manager.nix
+++ b/modules/nixos/general/home-manager.nix
@@ -5,6 +5,9 @@ with lib;
 {
   imports = [
     (import <home-manager> {}).nixos
+
+    # load the following when running a VM
+    # ("${builtins.fetchTarball https://github.com/rycee/home-manager/archive/nixos-module-user-pkgs.tar.gz}/nixos")
   ];
 
   options.mine.home-manager.config = mkOption {

--- a/modules/nixos/general/home-manager.nix
+++ b/modules/nixos/general/home-manager.nix
@@ -1,5 +1,17 @@
+{ lib, ... }:
+
+with lib;
+
 {
   imports = [
     (import <home-manager> {}).nixos
   ];
+
+  options.mine.home-manager.users = mkOption mkOption {
+    type = types.attrsOf hmModule;
+    default = {};
+    description = ''
+        Per-user Home Manager configuration.
+    '';
+  };
 }

--- a/modules/nixos/general/home-manager.nix
+++ b/modules/nixos/general/home-manager.nix
@@ -7,9 +7,8 @@ with lib;
     (import <home-manager> {}).nixos
   ];
 
-  options.mine.home-manager.users = mkOption mkOption {
-    type = types.attrsOf hmModule;
-    default = {};
+  options.mine.home-manager.config = mkOption {
+    default = { ... }: {};
     description = ''
         Per-user Home Manager configuration.
     '';

--- a/modules/nixos/general/home-manager.nix
+++ b/modules/nixos/general/home-manager.nix
@@ -8,9 +8,9 @@ with lib;
   ];
 
   options.mine.home-manager.config = mkOption {
-    default = { ... }: {};
+    default = { name, uid, isAdmin, nixosConfig }: {...}: {};
     description = ''
-        Per-user Home Manager configuration.
+      Function that returns the Home Manager configuration.
     '';
   };
 }

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -41,6 +41,9 @@ let
     });
 
   defaultUsers = {
+    # TODO: remove this once I move to yl users
+    kalbasit      = { uid = 1026; isAdmin = true; };
+
     yl            = { uid = 2000; isAdmin = false; };
     yl_admin      = { uid = 2001; isAdmin = true; };
     yl_opensource = { uid = 2002; isAdmin = false; };

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -69,15 +69,11 @@ in {
     users = {
       mutableUsers = false;
 
-      groups = {
-        mine = {
-          gid = 2000;
-        };
-      };
+      groups = { mine = { gid = 2000; }; };
 
-      users = {
-        root = { openssh.authorizedKeys.keys = sshKeys; };
-      } // (mapAttrs' makeUser config.mine.users);
+      users = mergeAttrs
+        { root = { openssh.authorizedKeys.keys = sshKeys; }; }
+        (mapAttrs' makeUser config.mine.users);
     };
 
     home-manager.users = mapAttrs' makeHM config.mine.users;

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
@@ -32,9 +32,16 @@ let
       openssh.authorizedKeys.keys = sshKeys;
     });
 
+  makeHM = name: attrs: nameValuePair
+    (name)
+    (config.mine.home-manager.config { attrs = attrs // {
+      inherit name;
+      nixosConfig = config;
+    }; });
+
   users = {
-    yl            = { uid = 2000; isAdmin = true; };
-    yl_admin      = { uid = 2001; isAdmin = false;};
+    yl            = { uid = 2000; isAdmin = false; };
+    yl_admin      = { uid = 2001; isAdmin = true;};
     yl_opensource = { uid = 2003; isAdmin = false;};
     yl_publica    = { uid = 2002; isAdmin = false;};
   };
@@ -56,4 +63,6 @@ in {
       root = { openssh.authorizedKeys.keys = sshKeys; };
     } // (mapAttrs' makeUser users);
   };
+
+  home-manager.users = mapAttrs' makeHM users;
 }

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -34,10 +34,11 @@ let
 
   makeHM = name: attrs: nameValuePair
     (name)
-    (config.mine.home-manager.config { attrs = attrs // {
+    (config.mine.home-manager.config {
+      inherit (attrs) uid isAdmin;
       inherit name;
       nixosConfig = config;
-    }; });
+    });
 
   users = {
     yl            = { uid = 2000; isAdmin = false; };

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -40,31 +40,43 @@ let
       nixosConfig = config;
     });
 
-  users = {
+  defaultUsers = {
     yl            = { uid = 2000; isAdmin = false; };
-    yl_admin      = { uid = 2001; isAdmin = true;};
-    yl_opensource = { uid = 2002; isAdmin = false;};
-
-    yl_publica    = { uid = 2016; isAdmin = false;}; # work uid should be indexed by start year
+    yl_admin      = { uid = 2001; isAdmin = true; };
+    yl_opensource = { uid = 2002; isAdmin = false; };
+    yl_publica    = { uid = 2016; isAdmin = false; };
   };
 
 in {
-  # set the initial password of the root user
-  security.initialRootPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
-
-  users = {
-    mutableUsers = false;
-
-    groups = {
-      mine = {
-        gid = 2000;
-      };
-    };
-
-    users = {
-      root = { openssh.authorizedKeys.keys = sshKeys; };
-    } // (mapAttrs' makeUser users);
+  options.mine.users = mkOption {
+    type = types.attrs;
+    default = defaultUsers;
+    defaultText = ''
+      The default users are ${builtins.concatStringsSep " " (builtins.attrNames defaultUsers)}
+    '';
+    description = ''
+      The list of users to create.
+    '';
   };
 
-  home-manager.users = mapAttrs' makeHM users;
+  config = {
+    # set the initial password of the root user
+    security.initialRootPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
+
+    users = {
+      mutableUsers = false;
+
+      groups = {
+        mine = {
+          gid = 2000;
+        };
+      };
+
+      users = {
+        root = { openssh.authorizedKeys.keys = sshKeys; };
+      } // (mapAttrs' makeUser config.mine.users);
+    };
+
+    home-manager.users = mapAttrs' makeHM config.mine.users;
+  };
 }

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -1,49 +1,53 @@
 { pkgs, ... }:
 
 {
-  # do not allow the users to be mutated
-  users.mutableUsers = false;
-
-  # define the root user
-  users.users.root = {
-    openssh.authorizedKeys.keys = [
-      (builtins.readFile (builtins.fetchurl {
-        url = "https://github.com/kalbasit.keys";
-        sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
-      }))
-    ];
-  };
-
   # set the initial password of the root user
   security.initialRootPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
 
-  programs.zsh = {
-    enable = true;
-    enableCompletion = true;
-  };
+  users = {
+    mutableUsers = false;
 
-  # define the users
-  users.users.kalbasit = {
-    extraGroups = [
-      "docker"
-      "fuse"
-      "libvirtd"
-      "networkmanager"
-      "vboxusers"
-      "video"
-      "wheel"
-    ];
+    groups = {
+      mine = {
+        gid = 2000;
+      };
+    };
 
-    shell = pkgs.zsh;
-    hashedPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
-    isNormalUser = true;
-    uid = 1026;
+    users = {
+      kalbasit = {
+        uid = 2000;
 
-    openssh.authorizedKeys.keys = [
-      (builtins.readFile (builtins.fetchurl {
-        url = "https://github.com/kalbasit.keys";
-        sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
-      }))
-    ];
+        group = "mine";
+        extraGroups = [
+          "docker"
+          "fuse"
+          "libvirtd"
+          "networkmanager"
+          "vboxusers"
+          "video"
+          "wheel"
+        ];
+
+        shell = pkgs.zsh;
+        hashedPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
+        isNormalUser = true;
+
+        openssh.authorizedKeys.keys = [
+          (builtins.readFile (builtins.fetchurl {
+            url = "https://github.com/kalbasit.keys";
+            sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
+          }))
+        ];
+      };
+
+      root = {
+        openssh.authorizedKeys.keys = [
+          (builtins.readFile (builtins.fetchurl {
+            url = "https://github.com/kalbasit.keys";
+            sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
+          }))
+        ];
+      };
+    };
   };
 }

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -1,6 +1,34 @@
 { pkgs, ... }:
 
-{
+let
+  sshKeys = [
+    (builtins.readFile (builtins.fetchurl {
+      url = "https://github.com/kalbasit.keys";
+      sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
+    }))
+  ];
+
+  makeUser = uid: admin: {
+    inherit uid;
+
+    group = "mine";
+    extraGroups = [
+      "docker"
+      "fuse"
+      "libvirtd"
+      "networkmanager"
+      "vboxusers"
+      "video"
+    ] ++ (if admin then ["wheel"] else []);
+
+    shell = pkgs.zsh;
+    hashedPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
+    isNormalUser = true;
+
+    openssh.authorizedKeys.keys = sshKeys;
+  };
+
+in {
   # set the initial password of the root user
   security.initialRootPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
 
@@ -14,40 +42,12 @@
     };
 
     users = {
-      kalbasit = {
-        uid = 2000;
+      yl = makeUser 2000 true;
+      yl_admin = makeUser 2001 false;
+      yl_opensource = makeUser 2003 false;
+      yl_publica = makeUser 2002 false;
 
-        group = "mine";
-        extraGroups = [
-          "docker"
-          "fuse"
-          "libvirtd"
-          "networkmanager"
-          "vboxusers"
-          "video"
-          "wheel"
-        ];
-
-        shell = pkgs.zsh;
-        hashedPassword = "$6$0bx5eAEsHJRxkD8.$gJ7sdkOOJRf4QCHWLGDUtAmjHV/gJxPQpyCEtHubWocHh9O7pWy10Frkm1Ch8P0/m8UTUg.Oxp.MB3YSQxFXu1";
-        isNormalUser = true;
-
-        openssh.authorizedKeys.keys = [
-          (builtins.readFile (builtins.fetchurl {
-            url = "https://github.com/kalbasit.keys";
-            sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
-          }))
-        ];
-      };
-
-      root = {
-        openssh.authorizedKeys.keys = [
-          (builtins.readFile (builtins.fetchurl {
-            url = "https://github.com/kalbasit.keys";
-            sha256 = "033rs0pnm8aiycrfmx04qx8fmnkfdhp4hy3kdpgil3cgbgff9736";
-          }))
-        ];
-      };
+      root = { openssh.authorizedKeys.keys = sshKeys; };
     };
   };
 }

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -42,8 +42,9 @@ let
   users = {
     yl            = { uid = 2000; isAdmin = false; };
     yl_admin      = { uid = 2001; isAdmin = true;};
-    yl_opensource = { uid = 2003; isAdmin = false;};
-    yl_publica    = { uid = 2002; isAdmin = false;};
+    yl_opensource = { uid = 2002; isAdmin = false;};
+
+    yl_publica    = { uid = 2016; isAdmin = false;}; # work uid should be indexed by start year
   };
 
 in {

--- a/modules/nixos/general/users.nix
+++ b/modules/nixos/general/users.nix
@@ -41,13 +41,7 @@ let
     });
 
   defaultUsers = {
-    # TODO: remove this once I move to yl users
     kalbasit      = { uid = 1026; isAdmin = true; };
-
-    yl            = { uid = 2000; isAdmin = false; };
-    yl_admin      = { uid = 2001; isAdmin = true; };
-    yl_opensource = { uid = 2002; isAdmin = false; };
-    yl_publica    = { uid = 2016; isAdmin = false; };
   };
 
 in {

--- a/modules/nixos/software/zsh.nix
+++ b/modules/nixos/software/zsh.nix
@@ -1,0 +1,6 @@
+{
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+  };
+}


### PR DESCRIPTION
This commit moves away from setting the `home-manager.users.<name>` directly from the `hosts/<host>/home.nix` into setting it on a new NixOS option. The new option is set to a function, given the user and nixosConfig, returns a new function to be set directly on `home-manager.users.<name>`. This way, I can dynamically create users as I need and configure the home of these users using the same function.